### PR TITLE
Update ImageManager.php: correctly explode image names with port number and tag

### DIFF
--- a/src/Docker/Manager/ImageManager.php
+++ b/src/Docker/Manager/ImageManager.php
@@ -71,7 +71,10 @@ class ImageManager
             $image->setId($data['Id']);
 
             foreach ($data['RepoTags'] as $repoTag) {
-                list($repository, $tag) = explode(':', $repoTag);
+                preg_match('/^(.*):(.*?)$/', $repoTag, $matches);
+
+                $repository = $matches[1];
+                $tag = $matches[2];
 
                 $tagImage = clone $image;
                 $tagImage->setRepository($repository);


### PR DESCRIPTION
Fix for exploding an image such as "registry.example.com:5000/my-image:latest"
